### PR TITLE
商品詳細表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 |condition_id     |integer|null: false |
 |charge_id        |integer|null: false |
 |area_id          |integer|null: false |
-|delivery_day_id  |integer|null: false |
+|delivery_id  |integer|null: false |
 |price            |integer|null: false |
 |description      |text   |null: false |
 |user             |references|foreign_key: true|

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new,:create]
+  before_action :set_item, only: [:show]
   def index
     @items = Item.all.order("created_at DESC")
   end
@@ -16,11 +17,19 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def show
+
+  end
   
   private
 
   def item_params
-    params.require(:item).permit(:product_name,:condition_id,:price,:image,:category_id,:condition_id,:charge_id,:area_id,:delivery_day_id,:description).merge(user_id: current_user.id)
+    params.require(:item).permit(:product_name,:condition_id,:price,:image,:category_id,:condition_id,:charge_id,:area_id,:delivery_id,:description).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,7 @@ class Item < ApplicationRecord
     validates :condition_id
     validates :charge_id
     validates :area_id
-    validates :delivery_day_id
+    validates :delivery_id
     end
 
 validates :image, presence: true, unless: :was_attached?

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "" do %>
+        <%= link_to item_path(item.id) do %>  
         
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -81,7 +81,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_day_id, Delivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_id, Delivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,13 +30,14 @@
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% if @item.present? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-     <% end %>
+    <% end %>
+     
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,11 +30,12 @@
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% else %>
+    <% end %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% if @item.present? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <% end %>
+    <% end %>   
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
      

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,12 +16,13 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.charge.name %>
       </span>
     </div>
+    
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -37,7 +38,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -47,23 +48,23 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,13 +26,17 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
+    <% if user_signed_in? && current_user.id == @item.user_id %>  
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if @item.present? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+     <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
@@ -104,7 +108,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
     
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
 
     <% if user_signed_in? && current_user.id == @item.user_id %>  
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
@@ -32,16 +32,14 @@
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% end %>
     <% if user_signed_in? && current_user.id != @item.user_id %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% if @item.present? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>   
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
      
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -109,9 +107,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
 </div>
 
 <%= render "shared/footer" %>

--- a/db/migrate/20210407121130_create_items.rb
+++ b/db/migrate/20210407121130_create_items.rb
@@ -1,6 +1,8 @@
 class CreateItems < ActiveRecord::Migration[6.0]
+
   def change
     create_table :items do |t|
+
 
       t.string     :content
       t.string     :product_name,   null: false
@@ -8,7 +10,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer    :condition_id,   null: false 
       t.integer    :charge_id,      null: false 
       t.integer    :area_id,        null: false 
-      t.integer    :delivery_day_id,null: false 
+      t.integer    :delivery_id,null: false 
       t.integer    :price,          null: false 
       t.text       :description,    null: false 
       t.references :user,           foreign_key: true

--- a/db/migrate/20210412040642_rename_account_name_column_to_accounts.rb
+++ b/db/migrate/20210412040642_rename_account_name_column_to_accounts.rb
@@ -1,0 +1,5 @@
+class RenameAccountNameColumnToAccounts < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :items, :delivery_day_id, :delivery_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_09_103403) do
+ActiveRecord::Schema.define(version: 2021_04_12_040642) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,9 +33,17 @@ ActiveRecord::Schema.define(version: 2021_04_09_103403) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "areas", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "area_id", null: false
+    t.string "municipalities", null: false
+    t.string "street_num", null: false
+    t.string "phone_num", null: false
+    t.string "building"
+    t.bigint "history_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["history_id"], name: "index_addresses_on_history_id"
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -58,19 +66,33 @@ ActiveRecord::Schema.define(version: 2021_04_09_103403) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_histories_on_item_id"
+    t.index ["user_id"], name: "index_histories_on_user_id"
+  end
+
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "product_name", null: false
     t.integer "category_id", null: false
     t.integer "condition_id", null: false
     t.integer "charge_id", null: false
     t.integer "area_id", null: false
-    t.integer "delivery_day_id", null: false
+    t.integer "delivery_id", null: false
     t.integer "price", null: false
     t.text "description", null: false
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -92,5 +114,8 @@ ActiveRecord::Schema.define(version: 2021_04_09_103403) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "histories"
+  add_foreign_key "histories", "items"
+  add_foreign_key "histories", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     condition_id      {2}
     charge_id         {2}
     area_id           {2}
-    delivery_day_id   {2}
+    delivery_id   {2}
     price             {55555}
 
     after(:build) do |item|


### PR DESCRIPTION
#What
商品の詳細を表示させる

#Why
商品の詳細を表示させるため

以下、GIf
ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること又、ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/3dff12a50e488c47c6c242e816cff402

ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/f343bb5ae8edaae255527258e126790e

ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること＆ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/58b83cc60278c99393d2bdffca556be5

尚、購入された商品に関する情報は『商品購入機能』が終わっていないのでGIFはありません





